### PR TITLE
fix some issue

### DIFF
--- a/Source/UIViewController+Options.swift
+++ b/Source/UIViewController+Options.swift
@@ -18,13 +18,24 @@ extension UIViewController {
     }
   
     func registerOptions(_ options: [SemiModalOption: Any]?) {
-        objc_setAssociatedObject(self, &CustomOptions, options, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+        // options always save in parent viewController
+        var targetVC: UIViewController = self
+        while targetVC.parent != nil {
+            targetVC = targetVC.parent!
+        }
+        
+        objc_setAssociatedObject(targetVC, &CustomOptions, options, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
     }
     
     func optionForKey(_ optionKey: SemiModalOption) -> Any? {
-        guard let options = objc_getAssociatedObject(self, &CustomOptions) as? [SemiModalOption: Any]
+        var targetVC: UIViewController = self
+        while targetVC.parent != nil {
+            targetVC = targetVC.parent!
+        }
+        
+        guard let options = objc_getAssociatedObject(targetVC, &CustomOptions) as? [SemiModalOption: Any]
             , let value = options[optionKey]  else {
-            return defaultOptions[optionKey]
+                return defaultOptions[optionKey]
         }
       
         switch optionKey {

--- a/Source/UIViewController+Options.swift
+++ b/Source/UIViewController+Options.swift
@@ -22,13 +22,68 @@ extension UIViewController {
     }
     
     func optionForKey(_ optionKey: SemiModalOption) -> Any? {
-        let options = objc_getAssociatedObject(self, &CustomOptions) as? [SemiModalOption: Any]
-      
-        if options?[optionKey] != nil {
-            return options?[optionKey]
-        } else {
+        guard let options = objc_getAssociatedObject(self, &CustomOptions) as? [SemiModalOption: Any]
+            , let value = options[optionKey]  else {
             return defaultOptions[optionKey]
         }
+      
+        switch optionKey {
+        case .traverseParentHierarchy:
+            if let value = value as? Bool {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .pushParentBack:
+            if let value = value as? Bool {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .animationDuration:
+            if let value = value as? TimeInterval {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .parentAlpha:
+            if let value = value as? Double {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .parentScale:
+            if let value = value as? Double {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .shadowOpacity:
+            if let value = value as? Double {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .transitionStyle:
+            if let value = value as? SemiModalTransitionStyle {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        case .disableCancel:
+            if let value = value as? Bool {
+                return value
+            }else{
+                return defaultOptions[optionKey]!
+            }
+        case .backgroundView:
+            if let value = value as? UIView {
+                return value
+            }else{
+                return defaultOptions[optionKey]
+            }
+        }
+        
     }
 
 }

--- a/Source/UIViewController+SemiModalViewController.swift
+++ b/Source/UIViewController+SemiModalViewController.swift
@@ -172,11 +172,11 @@ extension UIViewController {
         addOrUpdateParentScreenshotInView(overlay)
     }
     
-    @objc func dismissSemiModalView() {
+    @objc public func dismissSemiModalView() {
         dismissSemiModalViewWithCompletion(nil)
     }
     
-    func dismissSemiModalViewWithCompletion(_ completion: (() -> Void)?) {
+    public func dismissSemiModalViewWithCompletion(_ completion: (() -> Void)?) {
         let targetView = parentTargetView()
         guard let modal = targetView.viewWithTag(semiModalModalViewTag)
             , let overlay = targetView.viewWithTag(semiModalOverlayTag)

--- a/Source/UIViewController+SemiModalViewController.swift
+++ b/Source/UIViewController+SemiModalViewController.swift
@@ -45,8 +45,8 @@ extension UIViewController {
         targetParentVC.addChildViewController(vc)
         vc.beginAppearanceTransition(true, animated: true)
         
-        objc_setAssociatedObject(self, &semiModalViewController, vc, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        objc_setAssociatedObject(self, &semiModalDismissBlock, ClosureWrapper(closure: dismissBlock), .OBJC_ASSOCIATION_COPY_NONATOMIC)
+        objc_setAssociatedObject(targetParentVC, &semiModalViewController, vc, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(targetParentVC, &semiModalDismissBlock, ClosureWrapper(closure: dismissBlock), .OBJC_ASSOCIATION_COPY_NONATOMIC)
     
         presentSemiView(vc.view, options: options) {
             vc.didMove(toParentViewController: targetParentVC)
@@ -177,15 +177,17 @@ extension UIViewController {
     }
     
     public func dismissSemiModalViewWithCompletion(_ completion: (() -> Void)?) {
-        let targetView = parentTargetView()
-        guard let modal = targetView.viewWithTag(semiModalModalViewTag)
+        let targetVC = parentTargetViewController()
+        
+        guard let targetView = targetVC.view
+            , let modal = targetView.viewWithTag(semiModalModalViewTag)
             , let overlay = targetView.viewWithTag(semiModalOverlayTag)
             , let transitionStyle = optionForKey(.transitionStyle) as? SemiModalTransitionStyle
             , let duration = optionForKey(.animationDuration) as? TimeInterval else { return }
         
         
-        let vc = objc_getAssociatedObject(self, &semiModalViewController) as? UIViewController
-        let dismissBlock = (objc_getAssociatedObject(self, &semiModalDismissBlock) as? ClosureWrapper)?.closure
+        let vc = objc_getAssociatedObject(targetVC, &semiModalViewController) as? UIViewController
+        let dismissBlock = (objc_getAssociatedObject(targetVC, &semiModalDismissBlock) as? ClosureWrapper)?.closure
         
         vc?.willMove(toParentViewController: nil)
         vc?.beginAppearanceTransition(false, animated: true)
@@ -210,8 +212,8 @@ extension UIViewController {
             
             dismissBlock?()
             
-            objc_setAssociatedObject(self, &semiModalDismissBlock, nil, .OBJC_ASSOCIATION_COPY_NONATOMIC)
-            objc_setAssociatedObject(self, &semiModalViewController, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(targetVC, &semiModalDismissBlock, nil, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+            objc_setAssociatedObject(targetVC, &semiModalViewController, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             
             NotificationCenter.default.removeObserver(self, name: .UIDeviceOrientationDidChange, object: nil)
         }) 

--- a/Source/UIViewController+SemiModalViewController.swift
+++ b/Source/UIViewController+SemiModalViewController.swift
@@ -149,27 +149,27 @@ extension UIViewController {
         screenshotContainer.isHidden = true
         semiView?.isHidden = true
         
-        var snapshotView = screenshotContainer.viewWithTag(semiModalScreenshotTag)
-        snapshotView?.removeFromSuperview()
+        var snapshotView = screenshotContainer.viewWithTag(semiModalScreenshotTag) ?? UIView()
+        snapshotView.removeFromSuperview()
         
-        snapshotView = targetView.snapshotView(afterScreenUpdates: true)
-        snapshotView?.tag = semiModalScreenshotTag
+        snapshotView = targetView.snapshotView(afterScreenUpdates: true) ?? UIView()
+        snapshotView.tag = semiModalScreenshotTag
         
-        screenshotContainer.addSubview(snapshotView!)
+        screenshotContainer.addSubview(snapshotView)
         
         if optionForKey(.pushParentBack) as! Bool {
-            snapshotView?.layer.add(self.animationGroupForward(true), forKey: "pushedBackAnimation")
+            snapshotView.layer.add(self.animationGroupForward(true), forKey: "pushedBackAnimation")
         }
         
         screenshotContainer.isHidden = false
         semiView?.isHidden = false
         
-        return snapshotView!
+        return snapshotView
     }
     
     @objc func interfaceOrientationDidChange(_ notification: Notification) {
-        let overlay = parentTargetView().viewWithTag(semiModalOverlayTag)
-        addOrUpdateParentScreenshotInView(overlay!)
+        guard let overlay = parentTargetView().viewWithTag(semiModalOverlayTag) else { return }
+        addOrUpdateParentScreenshotInView(overlay)
     }
     
     @objc func dismissSemiModalView() {
@@ -178,11 +178,11 @@ extension UIViewController {
     
     func dismissSemiModalViewWithCompletion(_ completion: (() -> Void)?) {
         let targetView = parentTargetView()
-        let modal = targetView.viewWithTag(semiModalModalViewTag)!
-        let overlay = targetView.viewWithTag(semiModalOverlayTag)!
+        guard let modal = targetView.viewWithTag(semiModalModalViewTag)
+            , let overlay = targetView.viewWithTag(semiModalOverlayTag)
+            , let transitionStyle = optionForKey(.transitionStyle) as? SemiModalTransitionStyle
+            , let duration = optionForKey(.animationDuration) as? TimeInterval else { return }
         
-        let transitionStyle = optionForKey(.transitionStyle) as! SemiModalTransitionStyle
-        let duration = optionForKey(.animationDuration) as! TimeInterval
         
         let vc = objc_getAssociatedObject(self, &semiModalViewController) as? UIViewController
         let dismissBlock = (objc_getAssociatedObject(self, &semiModalDismissBlock) as? ClosureWrapper)?.closure
@@ -216,19 +216,20 @@ extension UIViewController {
             NotificationCenter.default.removeObserver(self, name: .UIDeviceOrientationDidChange, object: nil)
         }) 
         
-        let screenshot = overlay.subviews.first!
-        if optionForKey(.pushParentBack) as! Bool {
-            screenshot.layer.add(animationGroupForward(false), forKey: "bringForwardAnimation")
-        }
-        
-        UIView.animate(withDuration: duration, animations: { 
-            screenshot.alpha = 1
+        if let screenshot = overlay.subviews.first {
+            if let pushParentBack = optionForKey(.pushParentBack) as? Bool , pushParentBack {
+                screenshot.layer.add(animationGroupForward(false), forKey: "bringForwardAnimation")
+            }
+            UIView.animate(withDuration: duration, animations: {
+                screenshot.alpha = 1
             }, completion: { finished in
                 if finished {
                     NotificationCenter.default.post(name: .semiModalDidHide, object: self)
                     completion?()
                 }
-        }) 
+            })
+        }
+
     }
     
     func animationGroupForward(_ forward: Bool) -> CAAnimationGroup {


### PR DESCRIPTION
1. let childViewController can use `dismissSemiModalView` function
1. before get saved options, check option data type is match
1. reduce use swift unconditional unwrapping(!), sometimes will crash
1. objc_setAssociatedObject save in targetVC or rootVc , because when call `dismissSemiModalView` in the childViewController, it can not get `semiModalViewController` and  `semiModalDismissBlock`